### PR TITLE
Start the Redis server

### DIFF
--- a/files-for-container/setup_runner.py
+++ b/files-for-container/setup_runner.py
@@ -50,7 +50,7 @@ class SetupRunner:
             f'psql --user {postgres_user} --dbname digitalmarketplace --file {test_data_dump_filepath}')
 
     def stand_up_redis(self):
-        pass
+        self._run_shell_command("/etc/init.d/redis-server start")
 
     def start_apps(self):
         with open(f"{self.files_directory}/settings.yml", 'r') as stream:


### PR DESCRIPTION
This way of doing it mirrors what done for nginx and it seems to be the standard way for Debian.

I've tested this on the container and it seems to work fine: the buyer-frontend is able to connect to it.