### PR TITLE
Move the check that the test data file is present to the start of the setup

### DIFF
--- a/resources-for-container/files/env-runner/backend_services_data_importer.py
+++ b/resources-for-container/files/env-runner/backend_services_data_importer.py
@@ -1,3 +1,5 @@
+import os
+
 from environment import Environment
 from utils import display_status_banner
 
@@ -6,15 +8,15 @@ class BackendServicesDataImporter:
 
     def __init__(self, env: Environment):
         self.env = env
+        self.test_data_dump_filepath: str = self.env.mount_directory + "/test_data.sql"
+
+        self._check_test_data_file_is_present()
 
     def populate_postgres_with_test_data(self) -> None:
         display_status_banner("Populating Postgres with test data")
 
-        test_data_dump_filepath: str = self.env.mount_directory + "/test_data.sql"
-        # TODO raise error if test data file is not found
-
         self.env.run_safe_shell_command(
-            f'psql --user {self.env.POSTGRES_USER} --dbname digitalmarketplace --file {test_data_dump_filepath}')
+            f'psql --user {self.env.POSTGRES_USER} --dbname digitalmarketplace --file {self.test_data_dump_filepath}')
 
     def build_elasticsearch_indexes(self) -> None:
         display_status_banner("Building Elasticsearch indexes")
@@ -34,3 +36,7 @@ class BackendServicesDataImporter:
             --index=briefs-digital-outcomes-and-specialists \
             --frameworks=digital-outcomes-and-specialists-4 \
             --create-with-mapping=briefs-digital-outcomes-and-specialists-2""", scripts_directory)
+
+    def _check_test_data_file_is_present(self):
+        if not os.path.isfile(self.test_data_dump_filepath):
+            raise OSError(f"Test data file {self.test_data_dump_filepath} couldn't be found.")

--- a/resources-for-container/files/env-runner/backend_services_data_importer.py
+++ b/resources-for-container/files/env-runner/backend_services_data_importer.py
@@ -8,9 +8,7 @@ class BackendServicesDataImporter:
 
     def __init__(self, env: Environment):
         self.env = env
-        self.test_data_dump_filepath: str = self.env.mount_directory + "/test_data.sql"
-
-        self._check_test_data_file_is_present()
+        self.test_data_dump_filepath = self._get_test_data_dump_filepath()
 
     def populate_postgres_with_test_data(self) -> None:
         display_status_banner("Populating Postgres with test data")
@@ -37,6 +35,8 @@ class BackendServicesDataImporter:
             --frameworks=digital-outcomes-and-specialists-4 \
             --create-with-mapping=briefs-digital-outcomes-and-specialists-2""", scripts_directory)
 
-    def _check_test_data_file_is_present(self):
-        if not os.path.isfile(self.test_data_dump_filepath):
-            raise OSError(f"Test data file {self.test_data_dump_filepath} couldn't be found.")
+    def _get_test_data_dump_filepath(self) -> str:
+        test_data_dump_filepath = os.path.join(self.env.mount_directory, 'test_data.sql')
+        if not os.path.isfile(test_data_dump_filepath):
+            raise OSError(f"Test data file {test_data_dump_filepath} couldn't be found.")
+        return test_data_dump_filepath

--- a/resources-for-container/files/env-runner/start.py
+++ b/resources-for-container/files/env-runner/start.py
@@ -27,6 +27,8 @@ try:
 
     display_status_banner("SETUP STARTED")
 
+    backendServicesDataImporter = BackendServicesDataImporter(env)  # also checks that test data file is present
+
     env.prepare_scripts()
 
     backend_services = BackendServices(env)
@@ -39,7 +41,6 @@ try:
     AppsProvision(env, args.clear_venv_and_node_modules)\
         .provision_all_apps()
 
-    backendServicesDataImporter = BackendServicesDataImporter(env)
     backendServicesDataImporter.populate_postgres_with_test_data()
     backendServicesDataImporter.build_elasticsearch_indexes()
 

--- a/resources-for-container/files/env-runner/start.py
+++ b/resources-for-container/files/env-runner/start.py
@@ -24,10 +24,9 @@ try:
     args = parser.parse_args()
 
     env = Environment(args.dry_run)
+    backendServicesDataImporter = BackendServicesDataImporter(env)
 
     display_status_banner("SETUP STARTED")
-
-    backendServicesDataImporter = BackendServicesDataImporter(env)  # also checks that test data file is present
 
     env.prepare_scripts()
 


### PR DESCRIPTION
This PR fixes the issue that, in the case the test data file was not provided or was put in the wrong folder and/or with the wrong name, the user would have know about it only 20 mins into the setup, and they would have needed to start over.
This PR moves the check at the beginning on the process.