### PR TITLE
Update to Python 3.9

### DIFF
--- a/.github/workflows/digitalmarketplace-python-ci.yml
+++ b/.github/workflows/digitalmarketplace-python-ci.yml
@@ -8,7 +8,7 @@ jobs:
         working-directory: resources-for-container/files
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.9]
     steps:
     - uses: actions/checkout@v2
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6-slim-buster
+FROM python:3.9-slim-buster
 
 EXPOSE 80
 # these ports are proxied to the api apps (by nginx) as needed by the functional tests


### PR DESCRIPTION
https://crowncommercial.zendesk.com/agent/tickets/29816

digitalmarketplace-utils now needs at least 3.8, so we need to update (https://github.com/Crown-Commercial-Service/digitalmarketplace-utils/pull/698). We might as well take the latest whilst we're about it.